### PR TITLE
Badges and codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
 - "node"
+before_install:
+  - pip install --user codecov
+after_success:
+  - codecov --file coverage/lcov.info --disable search

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node ./tests/backend.js | tap-spec",
+    "test": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./tests/*.js | tap-spec",
     "coverage": "istanbul cover ./tests/backend.js",
     "nodemon": "nodemon ./src/server.js",
     "start": "node ./src/server.js"

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Jen-Harris/Tentacular.svg?branch=master)](https://travis-ci.org/Jen-Harris/Tentacular)
+
 # Tentacular!
 
 ## Why?

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/Jen-Harris/Tentacular.svg?branch=master)](https://travis-ci.org/Jen-Harris/Tentacular)
 
+[![codecov](https://codecov.io/gh/Jen-Harris/Tentacular/branch/master/graph/badge.svg)](https://codecov.io/gh/Jen-Harris/Tentacular)
+
 # Tentacular!
 
 ## Why?

--- a/tests/testnpmscript.js
+++ b/tests/testnpmscript.js
@@ -1,0 +1,6 @@
+const tape = require('tape');
+
+tape('see if this runs', t => {
+    t.equal(1,1, '1 =1');
+    t.end();
+})

--- a/tests/testnpmscript.js
+++ b/tests/testnpmscript.js
@@ -1,6 +1,0 @@
-const tape = require('tape');
-
-tape('see if this runs', t => {
-    t.equal(1,1, '1 =1');
-    t.end();
-})


### PR DESCRIPTION
Added travis build badge to README;
changed npm test scipt in package.json to run coverage, tape, tap-spec for multiple test files;
added codecov to .travis.yml.

Still to do: 
- [x]  make sure that codecov report is being generated and shown on PR.
- [x] put codecov badge into README (@Jen-Harris may need to do this, see [Dwyl tutorial](https://github.com/dwyl/learn-istanbul#tracking-coverage-as-a-service) and search for 'Add a badge' for how to. Also refer travis build badge in readme (its a markdown image and link).)